### PR TITLE
Fixed mistake in wallet.send_tokens abstraction example

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Once you have your Wallet, you can create a StdTx using `Wallet.create_and_sign_
 Or use the abstraction `wallet.send_tokens` (see `wallet.execute_tx` to execute a smart contract with `handle_msg`).
 
 ```
->>> tx = wallet.send_tokens(wallet.key.acc_address, RECIPIENT, "1000000uscrt")
+>>> tx = wallet.send_tokens(recipient_addr=RECIPIENT, transfer_amount="1000000uscrt")
 ```
 
 <br/>


### PR DESCRIPTION
The original example causes the tokens to be sent back to the wallet of the sender.