### PR TITLE
Add full async code example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,41 @@ If you want to make asynchronous, non-blocking LCD requests, you can use AsyncLC
 >>> asyncio.get_event_loop().run_until_complete(main())
 </code></pre>
 
+You can improve the efficiency of consecutive queries by making them asynchronous.
+
+<pre><code>
+>>> import asyncio
+>>> import uvloop
+
+>>> from secret_sdk.client.lcd import AsyncLCDClient
+>>> from secret_sdk.exceptions import LCDResponseError
+
+>>> def owner_of(token_id):
+        return {
+                "owner_of": {
+                    "token_id": token_id,
+                }
+            }
+
+>>> async def query_owner(secret, contract_address, token_id, query):
+        try:
+            msg = await secret.wasm.contract_query(contract_address, query)
+            return (token_id, msg["owner_of"]["owner"])
+        except LCDResponseError:
+            return (token_id, "")
+
+>>> async def query_collection(contract_address, token_ids):
+        <strong>async with AsyncLCDClient(chain_id="secret-4", url=node_rest_endpoint) as secret: </strong>
+            requests = [query_owner(secret, contract_address, token, owner_of(token)) for token in token_ids]
+            <strong>owners = await asyncio.gather(*requests, return_exceptions=True)</strong>
+            print(owners)
+            <strong>await secret.session.close() # you must close the session </strong>
+
+>>> uvloop.install()
+>>> if __name__ == '__main__':
+        asyncio.run(query_collection(contract_address, token_ids))
+</code></pre>
+
 ## Building and Signing Transactions
 
 If you wish to perform a state-changing operation on the Secret blockchain such as sending tokens, swapping assets, withdrawing rewards, or even invoking functions on smart contracts, you must create a **transaction** and broadcast it to the network.


### PR DESCRIPTION
## Changes
Currently there isn't an example of using the async client for speeding up consecutive queries which is quite useful for anyone executing large batches of queries (i.e. querying the owners of NFTs in a collection, querying a large number of addresses, etc.). Furthermore, there isn't an example in the docs of how to query a smart contract, so this example provides this additional benefit.

This PR adds a short, but detailed example of how to efficiently query the owners of NFTs in a collection using the async client.

Note: I purposefully excluded the declaration of the `contract_address` and `token_ids` variables in the code snippet to avoid specifying any particular NFT collection.

## Performance
The main reason to include this example is that the performance of the async client is much better than the regular client for large numbers of consecutive queries.

The speedup delivered for ~400 queries was non-trivial as the synchronous version took ~13 minutes while the asynchronous version took ~10 seconds, which is a reduction in execution time of >98%.