### PR TITLE
Added "out-of-the-box" support for batch transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,21 +205,13 @@ msg = {
   'increment': {}
 }
 
-execute_msg = secret.wasm.contract_execute_msg(
-  wallet.key.acc_address,
-  CONTRACT_ADDRESS,
-  msg
-)
+msg_list = [msg for _ in range(10)]
 
-msg_list = [execute_msg for _ in range(10)]
-
-signed_tx = wallet.create_and_sign_tx(
+tx = wallet.execute_tx(
+  CONTRACT_ADDR,
   msg_list,
-  fee=StdFee(200000, "120000uscrt"),
-  memo="My first batch transaction!"
+  memo="My first batch transaction!",
 )
-
-tx = secret.tx.broadcast(signed_tx)
 ```
 
 <br/>

--- a/secret_sdk/client/lcd/wallet.py
+++ b/secret_sdk/client/lcd/wallet.py
@@ -81,7 +81,7 @@ class AsyncWallet:
     async def execute_tx(
         self,
         contract_addr: str,
-        handle_msg: Dict,
+        handle_msg: List[Dict],
         memo: str = "",
         transfer_amount: Coins = None,
         gas: Optional[int] = None,
@@ -96,10 +96,14 @@ class AsyncWallet:
                 gas, gas_prices, gas_adjustment, fee_denoms
             )
 
-        execute_msg = await self.lcd.wasm.contract_execute_msg(
-            self.key.acc_address, contract_addr, handle_msg, transfer_amount
-        )
-        signed_tx = await self.create_and_sign_tx([execute_msg], fee=fee, memo=memo)
+        msg_list = []
+        for msg in handle_msg:
+            execute_msg = await self.lcd.wasm.contract_execute_msg(
+                self.key.acc_address, contract_addr, msg, transfer_amount
+            )
+            msg_list.append(execute_msg)
+
+        signed_tx = await self.create_and_sign_tx(msg_list, fee=fee, memo=memo)
         tx = await self.lcd.tx.broadcast(signed_tx)
         return tx
 
@@ -245,7 +249,7 @@ class Wallet:
     def execute_tx(
         self,
         contract_addr: str,
-        handle_msg: Dict,
+        handle_msg: List[Dict],
         memo: str = "",
         transfer_amount: Coins = None,
         gas: Optional[int] = None,
@@ -258,10 +262,14 @@ class Wallet:
         else:
             fee = self.lcd.tx.estimate_fee(gas, gas_prices, gas_adjustment, fee_denoms)
 
-        execute_msg = self.lcd.wasm.contract_execute_msg(
-            self.key.acc_address, contract_addr, handle_msg, transfer_amount
-        )
-        signed_tx = self.create_and_sign_tx([execute_msg], fee=fee, memo=memo)
+        msg_list = []
+        for msg in handle_msg:
+            execute_msg = self.lcd.wasm.contract_execute_msg(
+                self.key.acc_address, contract_addr, msg, transfer_amount
+            )
+            msg_list.append(execute_msg)
+
+        signed_tx = self.create_and_sign_tx(msg_list, fee=fee, memo=memo)
         tx = self.lcd.tx.broadcast(signed_tx)
         return tx
 


### PR DESCRIPTION
I thought it would be nice to offer out-of-the-box support for batch transactions with the execute_tx abstraction. I didn't see any way to get in touch with the creators of the SDK so I figured I would just go ahead and make a PR to get started. Another option would be to keep the execute_tx function as-is, and add another function such as execute_batch_tx. Looking forward to hearing some feedback from the team on the matter.