### PR TITLE
Add bank module method calls

### DIFF
--- a/integration_tests/staking_apr.py
+++ b/integration_tests/staking_apr.py
@@ -1,0 +1,25 @@
+from secret_sdk.client.localsecret import LocalSecret, main_net_chain_id
+
+
+def main():
+    secret_client = LocalSecret(
+        chain_id=main_net_chain_id,
+    )
+
+    network_inflation = 0.150   # 15%
+
+    pool_result = secret_client.staking.pool()
+    bonded = pool_result.bonded_tokens.amount / 10**6
+
+    community_result = secret_client.distribution.community_pool()
+    community_amount = community_result.get("uscrt").amount / 10**6
+
+    supply_result = secret_client.bank.total_denom("uscrt")
+    supply = supply_result.amount / 10**6
+
+    ratio = bonded / (supply - community_amount)
+    staking_apr = float(network_inflation / ratio)
+    print("staking_apr: ", staking_apr)
+
+
+main()

--- a/secret_sdk/client/lcd/__init__.py
+++ b/secret_sdk/client/lcd/__init__.py
@@ -1,4 +1,5 @@
 from .lcdclient import AsyncLCDClient, LCDClient
+from .params import PaginationOptions
 from .wallet import AsyncWallet, Wallet
 
-__all__ = ["AsyncLCDClient", "LCDClient", "AsyncWallet", "Wallet"]
+__all__ = ["AsyncLCDClient", "LCDClient", "AsyncWallet", "Wallet", "PaginationOptions"]

--- a/secret_sdk/client/lcd/api/bank.py
+++ b/secret_sdk/client/lcd/api/bank.py
@@ -1,27 +1,82 @@
-from secret_sdk.core import AccAddress, Coins
+from typing import Tuple, Optional
 
+from secret_sdk.core import AccAddress, Coins
+from secret_sdk.core.coin import Coin
+
+from ..params import APIParams
 from ._base import BaseAsyncAPI, sync_bind
 
 __all__ = ["AsyncBankAPI", "BankAPI"]
 
 
 class AsyncBankAPI(BaseAsyncAPI):
-    async def balance(self, address: AccAddress) -> Coins:
+    async def balance(
+        self, address: AccAddress, params: Optional[APIParams] = None
+    ) -> Tuple[Coins, dict]:
         """Fetches an account's current balance.
-
         Args:
             address (AccAddress): account address
-
+            params (APIParams, optional): additional params for the API like pagination
         Returns:
             Coins: balance
+            Pagination: pagination info
         """
-        res = await self._c._get(f"/bank/balances/{address}")
-        return Coins.from_data(res)
+        res = await self._c._get(f"/cosmos/bank/v1beta1/balances/{address}", params)
+        return Coins.from_data(res["balances"]), res.get("pagination")
+
+    async def total(self, params: Optional[APIParams] = None) -> Tuple[Coins, dict]:
+        """Fetches the current total supply of all tokens.
+        Returns:
+            Coins: total supply
+            params (APIParams, optional): additional params for the API like pagination
+        """
+        res = await self._c._get("/cosmos/bank/v1beta1/supply", params)
+        return Coins.from_data(res.get("supply")), res.get("pagination")
+
+    async def total_denom(self, denom: str, params: Optional[APIParams] = None) -> Coin:
+        """Fetches the current total supply of given token.
+        Returns:
+            Coins: total supply for denom
+            params (APIParams, optional): additional params for the API like pagination
+        """
+        res = await self._c._get(f"/cosmos/bank/v1beta1/supply/{denom}", params, True)
+        return Coin.parse(res['amount'])
+
+    async def spendable_balances(
+        self, address: AccAddress, params: Optional[APIParams] = None
+    ) -> Tuple[Coins, dict]:
+        """Queries the spenable balance of all coins for a single account
+        Returns:
+            Coins: spendable balance
+            params (APIParams, optional): additional params for the API like pagination
+        """
+        res = await self._c._get(
+            f"/cosmos/bank/v1beta1/spendable_balances/{address}", params
+        )
+        return Coins.from_data(res.get("balances")), res.get("pagination")
 
 
 class BankAPI(AsyncBankAPI):
     @sync_bind(AsyncBankAPI.balance)
-    def balance(self, address: AccAddress) -> Coins:
+    def balance(
+        self, address: AccAddress, params: Optional[APIParams] = None
+    ) -> Tuple[Coins, dict]:
         pass
 
     balance.__doc__ = AsyncBankAPI.balance.__doc__
+
+    @sync_bind(AsyncBankAPI.total_denom)
+    def total_denom(self, denom: str, params: Optional[APIParams] = None) -> Tuple[Coins, dict]:
+        pass
+
+    @sync_bind(AsyncBankAPI.total)
+    def total(self, params: Optional[APIParams] = None) -> Tuple[Coins, dict]:
+        pass
+
+    @sync_bind(AsyncBankAPI.spendable_balances)
+    def spendable_balances(self, params: Optional[APIParams] = None) -> Tuple[Coins, dict]:
+        pass
+
+    balance.__doc__ = AsyncBankAPI.balance.__doc__
+    total.__doc__ = AsyncBankAPI.total.__doc__
+    spendable_balances.__doc__ = AsyncBankAPI.spendable_balances.__doc__

--- a/secret_sdk/client/lcd/params.py
+++ b/secret_sdk/client/lcd/params.py
@@ -1,0 +1,66 @@
+import abc
+from abc import ABC
+from typing import Optional
+
+__all__ = ["APIParams", "PaginationOptions"]
+
+
+class APIParams(ABC):
+    @abc.abstractmethod
+    def to_dict(self):
+        pass
+
+    def to_list(self) -> list:
+        lst = []
+        dct = self.to_dict()
+        for key in dct.keys():
+            lst.append((key, dct.get(key)))
+        return lst
+
+
+class PaginationOptions(APIParams):
+    """This could be used when you need pagination options for APIs
+    Args:
+        key (str): key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+        offset (int): offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should be set.
+        limit (int): limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+        count_total (bool): count_total is set to true to indicate that the result set should include a count of
+            the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key is set.
+        reverse (bool): reverse is set to true if results are to be returned in the descending order.
+    """
+
+    def __init__(
+        self,
+        key: Optional[str] = None,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        count_total: Optional[bool] = None,
+        reverse: Optional[bool] = None,
+    ):
+        self.key = key
+        self.offset = offset
+        self.limit = limit
+        self.count_total = count_total
+        self.reverse = reverse
+
+    def __str__(self):
+        return "&".join(self.to_dict())
+
+    def to_dict(self):
+        params = {}
+        if self.key is not None:
+            params["pagination.key"] = self.key
+        if self.offset is not None:
+            params["pagination.offset"] = self.offset
+        if self.limit is not None:
+            params["pagination.limit"] = self.limit
+        if self.count_total is not None:
+            params["pagination.count_total"] = str(self.count_total).lower()
+        if self.reverse is not None:
+            params["pagination.reverse"] = str(self.reverse).lower()
+        return params


### PR DESCRIPTION
Added following methods:

1. /cosmos/bank/v1beta1/supply
2. /cosmos/bank/v1beta1/supply/{denom}
3. /cosmos/bank/v1beta1/spendable_balances/{address}

Added integration test `staking_apr.py` which uses `uscrt` supply from bank module request.